### PR TITLE
Add new allocator: LaughStorage Allocator

### DIFF
--- a/allocators/recQ0CAUmjmUpFy4m.json
+++ b/allocators/recQ0CAUmjmUpFy4m.json
@@ -1,0 +1,48 @@
+{
+  "application_number": 1337,
+  "address": "f2srgcxkj3zzy36t24lobqueerddnr4cqmfzq6dbq",
+  "name": "LaughStorage Allocator",
+  "organization": "LaughStorage",
+  "location": [
+    "Greater China Region"
+  ],
+  "status": "Active",
+  "metapathway_type": "Automatic",
+  "associated_org_addresses": [
+    "f2srgcxkj3zzy36t24lobqueerddnr4cqmfzq6dbq",
+    "f1rezheyjsdejlxgssaqkvtg5buhsiubevgsbyjsa "
+  ],
+  "application": {
+    "allocations": {
+      "standardized": []
+    },
+    "target_clients": [
+      "Web3 developers",
+      "Nonprofit organizations",
+      "Commercial/Enterprise",
+      "Individuals",
+      "Open/Public"
+    ],
+    "required_sps": "3+",
+    "required_replicas": "3+",
+    "data_types": [
+      "Private encrypted with on-chain deal pricing",
+      "Public, open, and retrievable"
+    ],
+    "github_handles": [
+      "26dos"
+    ],
+    "allocation_bookkeeping": "https://github.com/26dos/AllocatorBookkeeping"
+  },
+  "poc": {
+    "slack": "Laugh Storage",
+    "github_user": "26dos"
+  },
+  "pathway_addresses": {
+    "msig": "f2srgcxkj3zzy36t24lobqueerddnr4cqmfzq6dbq",
+    "signer": [
+      "s1",
+      "s2"
+    ]
+  }
+}


### PR DESCRIPTION
# Filecoin Plus Allocator Application

## Application Details
| Field | Value |
|-------|-------|
| Number | `77` |
| Applicant | LaughStorage Allocator |
| Organization | LaughStorage |
| Address | [f2srgcxkj3zzy36t24lobqueerddnr4cqmfzq6dbq](https://filfox.info/en/address/f2srgcxkj3zzy36t24lobqueerddnr4cqmfzq6dbq) |
| GitHub Username | [![GitHub](https://img.shields.io/badge/GitHub-26dos?style=flat-square&logo=github)](https://github.com/26dos) |
| Location | Greater China Region |
| Type | `undefined` |
| Submission Date | `2024-09-30` |

---
<sup>This message was automatically generated by the Filecoin Plus Bot. For more information, visit [filecoin.io](https://filecoin.io)</sup>